### PR TITLE
Log estilo nginx

### DIFF
--- a/buchonip.go
+++ b/buchonip.go
@@ -40,6 +40,14 @@ func parse_ip(remoteAddr string) string {
 	return remoteAddr[:semicolonIndex]
 }
 
+func log_request(remote_ip *string, req *http.Request) {
+	log.Printf("%s - \"%s %s\" _code _size %s",
+		*remote_ip,
+		req.Method,
+		req.URL,
+		req.Header["User-Agent"])
+}
+
 func homeHandler(res http.ResponseWriter, req *http.Request) {
 	res.Header().Set("Server", "BuchonIP/0.1")
 	res.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -49,7 +57,7 @@ func homeHandler(res http.ResponseWriter, req *http.Request) {
 
 	gAnalId := os.Getenv("GOOGLE_ANALYTICS_ID")
 
-	log.Printf("Incoming request from %s", remote_ip)
+	log_request(&remote_ip, req)
 	fmt.Fprintf(res, HTMLPage, gAnalId, gAnalId, remote_ip)
 }
 
@@ -59,7 +67,7 @@ func jsonHandler(res http.ResponseWriter, req *http.Request) {
 
 	remote_ip := parse_ip(req.RemoteAddr)
 
-	log.Printf("Incoming request from %s", remote_ip)
+	log_request(&remote_ip, req)
 	fmt.Fprintf(res, "{\"ip\": \"%s\"}", remote_ip)
 }
 
@@ -69,7 +77,7 @@ func txtHandler(res http.ResponseWriter, req *http.Request) {
 
 	remote_ip := parse_ip(req.RemoteAddr)
 
-	log.Printf("Incoming request from %s", remote_ip)
+	log_request(&remote_ip, req)
 	fmt.Fprintf(res, remote_ip)
 }
 


### PR DESCRIPTION
Hugo, fijate cómo lo ves.

Hay un tema de punteros que medio probé y anduvieron :ocean: 
Después, no pude leer el Response (entiendo que aún no existe en esa instancia y no supe agregarlo) así que no muestro ni el status que respondo ni el size de bytes :-1: 

Lo positivo es que es un log más copado que el que teníamos.

```
$ go run buchonip.go 
2018/11/22 22:34:00 Listening at http://127.0.0.1:8080
2018/11/22 22:34:03 127.0.0.1 - "GET /" _code _size Mozilla/5.0 (X11; Linux x86_64; rv:63.0) Gecko/20100101 Firefox/63.0
2018/11/22 22:34:03 127.0.0.1 - "GET /favicon.ico" _code _size Mozilla/5.0 (X11; Linux x86_64; rv:63.0) Gecko/20100101 Firefox/63.0
```